### PR TITLE
Correct command for help added

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -37,7 +37,7 @@ cabal configure --with-compiler=ghc-8.10.7
 
 #### Running the project
 ```
-  cabal build
-  cabal run market-cli help
+  cabal install market-cli
+  market-cli --help
 ```
 For detaied options [Cli-docs](./cli.md)


### PR DESCRIPTION
In the README of cabal build local, the command for market-cli help did not use to work, so changes are made to the README. 